### PR TITLE
Populate private fields if no setter or public field found

### DIFF
--- a/beanmother-core/src/main/java/io/beanmother/core/mapper/SetterAndFieldFixtureMapper.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/mapper/SetterAndFieldFixtureMapper.java
@@ -123,7 +123,15 @@ public class SetterAndFieldFixtureMapper extends AbstractFixtureMapper implement
 
     private void bindByField(Object target, String key, FixtureTemplate template) {
         Field field = findField(target.getClass(), key);
-        if (field == null) return;
+        if (field == null) {
+            //Lets try private fields as well
+            try {
+                field = target.getClass().getDeclaredField(key);
+                field.setAccessible(true);//Very important, this allows the setting to work.
+            } catch (NoSuchFieldException e) {
+                return;
+            }
+        }
 
         TypeToken<?> targetType = TypeToken.of(field.getGenericType());
         Object value = getFixtureConverter().convert(template, targetType);

--- a/beanmother-core/src/test/java/io/beanmother/core/mapper/FixtureValueFieldMapperTest.java
+++ b/beanmother-core/src/test/java/io/beanmother/core/mapper/FixtureValueFieldMapperTest.java
@@ -40,6 +40,24 @@ public class FixtureValueFieldMapperTest {
     }
 
     @Test
+    public void testPrivateSimpleObjectMapping() {
+        FieldObject obj = new FieldObject();
+
+        mapper.map(obj, "pvtInteger", new FixtureValue(10));
+        assertEquals(obj.pvtInteger, new Integer(10));
+
+        mapper.map(obj, "pvtPrimitiveInt", new FixtureValue(11));
+        assertEquals(obj.pvtPrimitiveInt, 11);
+
+        Date date = new Date();
+        mapper.map(obj, "pvtDate", new FixtureValue(date));
+        assertEquals(obj.pvtDate, date);
+
+        mapper.map(obj, "pvtString", new FixtureValue("test"));
+        assertEquals(obj.pvtString, "test");
+    }
+
+    @Test
     public void testCastingAndMapping() {
         FieldObject obj = new FieldObject();
         mapper.map(obj, "number", new FixtureValue(10));
@@ -56,5 +74,12 @@ public class FixtureValueFieldMapperTest {
         public Float ploat;
         public Date date;
         public String string;
+
+        private int pvtPrimitiveInt;
+        private Integer pvtInteger;
+        private Number pvtNumber;
+        private Float pvtPloat;
+        private Date pvtDate;
+        private String pvtString;
     }
 }


### PR DESCRIPTION
If there is not a setter or a public field, then try and populate the private field as a last resort.