### PR TITLE
Specify custom setter prefix when using BuilderObjectMother

### DIFF
--- a/beanmother-builder-converter/src/main/java/io/beanmother/builder/BuilderObjectMother.java
+++ b/beanmother-builder-converter/src/main/java/io/beanmother/builder/BuilderObjectMother.java
@@ -26,6 +26,7 @@ public class BuilderObjectMother extends AbstractBeanMother {
     public final static String FINISH_BUILDER_KEY = "_finishBuilder";
 	public final static String TARGET_BUILDER_KEY = "_targetClass";
 	public final static String CONSTRUCT_BUILDER_KEY = "_construct";
+	public final static String SETTER_PREFIX_KEY = "_setterPrefix";
 
     public BuilderObjectMother() {
     	super();
@@ -59,13 +60,17 @@ public class BuilderObjectMother extends AbstractBeanMother {
 	        }
 	    } else if (fixtureMap.containsKey(CONSTRUCT_BUILDER_KEY)) {
 			// Use the target class by fixture, not by method call
-			FixtureValue targetFixtureAux = (FixtureValue)fixtureMap.get(TARGET_BUILDER_KEY);
+			FixtureValue targetFixtureAux = (FixtureValue) fixtureMap.get(TARGET_BUILDER_KEY);
 			try {
 				inst = (T) ConstructHelper.construct(Class.forName(targetFixtureAux.getValue().toString()), fixtureMap, null);
 			} catch (ClassNotFoundException e) {
 				e.printStackTrace();
 			}
-		}     
+		}
+		if (fixtureMap.containsKey(SETTER_PREFIX_KEY)) {
+			FixtureValue customSetter = (FixtureValue) fixtureMap.get(SETTER_PREFIX_KEY);
+        	this.setSetterPrefix((String) customSetter.getValue());
+		}
 		
 		if (inst!=null) {
 			_bear(inst, fixtureMap, postProcessor);

--- a/beanmother-builder-converter/src/test/java/io/beanmother/grpc/GRPCObjectMotherTest.java
+++ b/beanmother-builder-converter/src/test/java/io/beanmother/grpc/GRPCObjectMotherTest.java
@@ -1,7 +1,5 @@
 package io.beanmother.grpc;
 
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -10,12 +8,14 @@ import io.beanmother.builder.BuilderObjectMother;
 import io.beanmother.grpc.GrpcBuilderClass;
 import io.beanmother.grpc.GrpcBuilderClass.BuilderPC;
 
+import static org.junit.Assert.*;
+
 /**
- * Test for {@link GRPCObjectMother}
+ * Test for {@link BuilderObjectMother}
  */
 public class GRPCObjectMotherTest {
 
-	BuilderObjectMother objectMother = BuilderObjectMother.getInstance();
+	private BuilderObjectMother objectMother = BuilderObjectMother.getInstance();
 	
     @Before
     public void setup(){
@@ -25,49 +25,49 @@ public class GRPCObjectMotherTest {
     @Test
     public void testBuilderAndAttr() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder", GrpcBuilderClass.class);
-    	assertTrue("1".equals(((GrpcBuilderClass)obj).getAttr1()));
+        assertEquals("1", obj.getAttr1());
     }
 
 	@Test
     public void testBuilderAttrNonExisting() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder-attr-non-existing", GrpcBuilderClass.class);
-    	assertTrue("1".equals(((GrpcBuilderClass)obj).getAttr1()));
+        assertEquals("1", obj.getAttr1());
     } 
 
     @Test
     public void testBuilderInitNonExisting() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder-init-non-existing", GrpcBuilderClass.class);
-    	assertTrue(null==obj);
+        assertNull(obj);
     }  
 
     @Test
     public void testBuilderInitParamNotFound() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder-init-param-not-found", GrpcBuilderClass.class);
-    	assertTrue(null==obj);
+        assertNull(obj);
     } 
     
     @Test
     public void testBuilderFinishNonExisting() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder-finish-non-existing", GrpcBuilderClass.class);
-    	assertTrue(null==obj);
+        assertNull(obj);
     }  
 
     @Test
     public void testBuilderFinishParamNotFound() {
         BuilderPC obj = objectMother.bear("pattern-builder-finish-param-not-found", BuilderPC.class);
-    	assertTrue(null==obj);
+        assertNull(obj);
     }     
 
     @Test
     public void testBuilderTargetNonExisting() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder-targetclass-non-existing", GrpcBuilderClass.class);
-    	assertTrue(null==obj);
+        assertNull(obj);
     } 
 
     @Test
     public void testBuilderTargetNotFound() {
     	GrpcBuilderClass obj = objectMother.bear("pattern-builder-targetclass-not-found", GrpcBuilderClass.class);
-    	assertTrue(null==obj);
+        assertNull(obj);
     }     
 
 }

--- a/beanmother-builder-converter/src/test/java/io/beanmother/grpcCustom/GRPCCustomSetterObjectMotherTest.java
+++ b/beanmother-builder-converter/src/test/java/io/beanmother/grpcCustom/GRPCCustomSetterObjectMotherTest.java
@@ -1,0 +1,33 @@
+package io.beanmother.grpcCustom;
+
+import io.beanmother.builder.BuilderObjectMother;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link BuilderObjectMother}
+ */
+public class GRPCCustomSetterObjectMotherTest {
+
+    private BuilderObjectMother objectMother = BuilderObjectMother.getInstance();
+
+    @Before
+    public void setup() {
+        objectMother.addFixtureLocation("testmodel_fixtures");
+    }
+
+    @Test
+    public void testBuilderAndAttr() {
+        GrpcBuilderCustomSetterClass obj = objectMother.bear("pattern-builder-custom-setter", GrpcBuilderCustomSetterClass.class);
+        assertEquals("1", obj.getAttr1());
+    }
+
+    @Test
+    public void testBuilderAttrNonExisting() {
+        GrpcBuilderCustomSetterClass obj = objectMother.bear("pattern-builder-custom-setter-non-existing", GrpcBuilderCustomSetterClass.class);
+        assertEquals("1", obj.getAttr1());
+    }
+
+}

--- a/beanmother-builder-converter/src/test/java/io/beanmother/grpcCustom/GrpcBuilderCustomSetterClass.java
+++ b/beanmother-builder-converter/src/test/java/io/beanmother/grpcCustom/GrpcBuilderCustomSetterClass.java
@@ -1,0 +1,43 @@
+package io.beanmother.grpcCustom;
+
+public final class GrpcBuilderCustomSetterClass {
+
+	private String attr1;
+
+	public static BuilderPC newBuilder() {
+		return new BuilderPC();
+	}
+
+	public static final class BuilderPC {
+
+		private static GrpcBuilderCustomSetterClass pbc;
+
+		private BuilderPC() {
+			pbc = new GrpcBuilderCustomSetterClass();
+		}
+
+		public BuilderPC withAttr1(String value) {
+			pbc.attr1 = value;
+			return this;
+		}
+
+		public GrpcBuilderCustomSetterClass build() {
+			return pbc;
+		}
+	}
+
+	private GrpcBuilderCustomSetterClass() {
+		attr1 = "";
+	}
+
+	public String getAttr1() {
+		return attr1;
+	}
+
+	public static void main(String[] args) {
+		GrpcBuilderCustomSetterClass pbc = GrpcBuilderCustomSetterClass.newBuilder().withAttr1("attr1").build();
+		System.out.println(pbc.getAttr1());
+	}
+	
+}
+

--- a/beanmother-builder-converter/src/test/resources/fixtures/builder.yml
+++ b/beanmother-builder-converter/src/test/resources/fixtures/builder.yml
@@ -4,12 +4,28 @@ pattern-builder:
   _targetClass: io.beanmother.grpc.GrpcBuilderClass$BuilderPC
   attr1: 1
 
+pattern-builder-custom-setter:
+  _initBuilder: newBuilder
+  _finishBuilder: build
+  _targetClass: io.beanmother.grpcCustom.GrpcBuilderCustomSetterClass$BuilderPC
+  _setterPrefix: with
+  attr1: 1
+
 pattern-builder-attr-non-existing:
   _initBuilder: newBuilder
   _finishBuilder: build
   _targetClass: io.beanmother.grpc.GrpcBuilderClass$BuilderPC
   attr1: 1
   nonExistAttr: 2
+
+pattern-builder-custom-setter-non-existing:
+  _initBuilder: newBuilder
+  _finishBuilder: build
+  _targetClass: io.beanmother.grpcCustom.GrpcBuilderCustomSetterClass$BuilderPC
+  _setterPrefix: with
+  attr1: 1
+  nonExistAttr: 2
+
 
 pattern-builder-init-non-existing:
   _initBuilder: notNewBuilder

--- a/beanmother-core/src/main/java/io/beanmother/core/AbstractBeanMother.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/AbstractBeanMother.java
@@ -150,6 +150,10 @@ public abstract class AbstractBeanMother implements BeanMother {
         configurePostProcessorFactory(postProcessorFactory);
     }
 
+    protected void setSetterPrefix(String prefix) {
+        this.fixtureMapper.setSetterPrefix(prefix);
+    }
+
     private void handleScriptFixtureValue(FixtureMap fixtureMap) {
         FixtureMapTraversal.traverse(fixtureMap, new FixtureMapTraversal.Processor() {
             @Override

--- a/beanmother-core/src/main/java/io/beanmother/core/mapper/DefaultFixtureMapper.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/mapper/DefaultFixtureMapper.java
@@ -25,6 +25,11 @@ public class DefaultFixtureMapper implements FixtureMapper, MapperMediator {
     }
 
     @Override
+    public void setSetterPrefix(String setterPrefix) {
+        getFixtureMapper().setSetterPrefix(setterPrefix);
+    }
+
+    @Override
     public FixtureMapper getFixtureMapper() {
         return mapperMediator.getFixtureMapper();
     }

--- a/beanmother-core/src/main/java/io/beanmother/core/mapper/FixtureMapper.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/mapper/FixtureMapper.java
@@ -19,4 +19,6 @@ public interface FixtureMapper {
      * @param target
      */
     void map(FixtureMap fixtureMap, Object target);
+
+    void setSetterPrefix(String setterPrefix);
 }

--- a/beanmother-core/src/main/java/io/beanmother/core/mapper/SetterAndFieldFixtureMapper.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/mapper/SetterAndFieldFixtureMapper.java
@@ -8,8 +8,6 @@ import io.beanmother.core.common.FixtureList;
 import io.beanmother.core.common.FixtureMap;
 import io.beanmother.core.common.FixtureTemplate;
 import io.beanmother.core.common.FixtureValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -22,20 +20,22 @@ import java.util.List;
  * It maps target object properties by setter and maps public field as a fallback.
  */
 public class SetterAndFieldFixtureMapper extends AbstractFixtureMapper implements FixtureMapper {
-    private final static Logger logger = LoggerFactory.getLogger(SetterAndFieldFixtureMapper.class);
-
     /**
      * A prefix of setter names
      */
-    private final static String SETTER_PREFIX = "set";
+    private String SETTER_PREFIX = "set";
 
     /**
      * Create a SetterAndFieldFixtureMapper
      *
-     * @param mapperMediator
      */
     public SetterAndFieldFixtureMapper(MapperMediator mapperMediator) {
         super(mapperMediator);
+    }
+
+    @Override
+    public void setSetterPrefix(String setterPrefix) {
+        this.SETTER_PREFIX = setterPrefix;
     }
 
     @Override
@@ -113,7 +113,7 @@ public class SetterAndFieldFixtureMapper extends AbstractFixtureMapper implement
         for (Method method : methods) {
             String name = method.getName();
             if(name.indexOf(SETTER_PREFIX) == 0) {
-                if (name.substring(SETTER_PREFIX.length(), name.length()).equalsIgnoreCase(key)) {
+                if (name.substring(SETTER_PREFIX.length()).equalsIgnoreCase(key)) {
                     result.add(method);
                 }
             }
@@ -127,7 +127,7 @@ public class SetterAndFieldFixtureMapper extends AbstractFixtureMapper implement
             //Lets try private fields as well
             try {
                 field = target.getClass().getDeclaredField(key);
-                field.setAccessible(true);//Very important, this allows the setting to work.
+                field.setAccessible(true); //Very important, this allows the setting to work.
             } catch (NoSuchFieldException e) {
                 return;
             }


### PR DESCRIPTION
Allows to populate Builder classes that use special setter prefixes, such 'with'.