### PR TITLE
Changed SetterAndFieldFixtueMapper so it can set private fields of super-classes without setter available.

### DIFF
--- a/beanmother-core/src/main/java/io/beanmother/core/mapper/SetterAndFieldFixtureMapper.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/mapper/SetterAndFieldFixtureMapper.java
@@ -127,11 +127,11 @@ public class SetterAndFieldFixtureMapper extends AbstractFixtureMapper implement
             //Lets try private fields as well
             try {
                 field = target.getClass().getDeclaredField(key);
-                field.setAccessible(true);//Very important, this allows the setting to work.
             } catch (NoSuchFieldException e) {
                 return;
             }
         }
+        field.setAccessible(true);//Very important, this allows the setting to work.
 
         TypeToken<?> targetType = TypeToken.of(field.getGenericType());
         Object value = getFixtureConverter().convert(template, targetType);
@@ -146,7 +146,7 @@ public class SetterAndFieldFixtureMapper extends AbstractFixtureMapper implement
 
     private Field findField(Class<?> targetClass, String key) {
         try {
-            return targetClass.getField(key);
+        	return targetClass.getDeclaredField(key);
         } catch (NoSuchFieldException e) {
             Class<?> superClass = targetClass.getSuperclass();
             if (superClass == null || superClass == Object.class) {

--- a/beanmother-core/src/test/java/io/beanmother/core/mapper/FixtureValueFieldMapperTest.java
+++ b/beanmother-core/src/test/java/io/beanmother/core/mapper/FixtureValueFieldMapperTest.java
@@ -66,6 +66,13 @@ public class FixtureValueFieldMapperTest {
         mapper.map(obj, "ploat", new FixtureValue(10));
         assertEquals(obj.ploat, new Float(10));
     }
+    
+    @Test
+    public void testPrivateSimpleChildObjectMapping() {
+    	FieldChildObject childObj = new FieldChildObject();
+        mapper.map(childObj, "pvtString", new FixtureValue("test"));
+        assertEquals(childObj.getPvtString(), "test");
+    }
 
     public static class FieldObject {
         public int primitiveInt;
@@ -81,5 +88,17 @@ public class FixtureValueFieldMapperTest {
         private Float pvtPloat;
         private Date pvtDate;
         private String pvtString;
+    }
+    
+    public static class FieldParentObject {
+        private String pvtString;
+        
+        public String getPvtString () {
+        	return pvtString;
+        }
+    }
+    
+    public static class FieldChildObject extends FieldParentObject {
+    	
     }
 }


### PR DESCRIPTION
It was not possible to create an object with a private field without setter in the superclass. 

We need this in our project, because we have classes that were automatically generated by cxf. They only have getter and no setter in lists.

I added the test-case testPrivateSimpleChildObjectMapping in FixtureValueFieldMapperTest.java