### PR TITLE
enums: allow custom to string implementations

### DIFF
--- a/beanmother-core/src/main/java/io/beanmother/core/converter/std/StringToEnumConverter.java
+++ b/beanmother-core/src/main/java/io/beanmother/core/converter/std/StringToEnumConverter.java
@@ -16,10 +16,12 @@ public class StringToEnumConverter extends AbstractConverter {
 
         Class enumClass = targetTypeToken.getRawType();
         for (Object enumConstant : enumClass.getEnumConstants()) {
-            String enumStr = enumConstant.toString().replaceAll("\\_", "");
-            String sourceStr = ((String) source).replaceAll("\\-", "").replaceAll("\\_", "").replaceAll("\\s", "");
+            Enum constant = (Enum) enumConstant;
+            String enumStr = constant.name();
+            String sourceStr = ((String) source);
+
             if (enumStr.equalsIgnoreCase(sourceStr)) {
-                return Enum.valueOf(enumClass, enumConstant.toString());
+                return enumConstant;
             }
         }
 


### PR DESCRIPTION
As per the [enum spec](https://docs.oracle.com/javase/7/docs/api/java/lang/Enum.html)
* name() is final and can't change. It refers to the exact defined name of the constant, as declared in the enum.
* toString() is arbitrary and can be developer overridden. It defaults to name()

So, this should use name() instead of toString(), in-case a developer (today, me) overrides the toString of an enum.